### PR TITLE
Fix output option null bug

### DIFF
--- a/src/JsonMerge.CommandLine/Program.cs
+++ b/src/JsonMerge.CommandLine/Program.cs
@@ -38,6 +38,11 @@ namespace JsonMerge.CommandLine
 
         public static int Merge(FileInfo[] inputFiles, FileInfo output, bool force, IConsole console)
         {
+            if (output == null)
+            {
+                console.Error.WriteLine("Output file path is required.");
+                return 1;
+            }
             var sourceJsons = inputFiles.Select(f => File.ReadAllText(f.FullName));
             var mergedJson = JsonMerger.Merge(sourceJsons);
 


### PR DESCRIPTION
## Summary
- handle null `--output` option in `Merge` command

## Testing
- `dotnet --version` *(fails: command not found)*