### PR TITLE
Clarify CLI usage

### DIFF
--- a/src/JsonMerge.CommandLine/Program.cs
+++ b/src/JsonMerge.CommandLine/Program.cs
@@ -77,6 +77,7 @@ namespace JsonMerge.CommandLine
         private static void PrintUsage()
         {
             Console.Error.WriteLine("Usage: jsonmerge <input1> <input2> [<inputN>...] -o <output> [-f]");
+            Console.Error.WriteLine("The -o|--output option is required.");
         }
     }
 }


### PR DESCRIPTION
## Summary
- clarify that the `-o`/`--output` option is mandatory

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*